### PR TITLE
Add simple registration and admin pages

### DIFF
--- a/project/data/registrations.xml
+++ b/project/data/registrations.xml
@@ -1,0 +1,1 @@
+<registrations></registrations>

--- a/project/src/components/Header.astro
+++ b/project/src/components/Header.astro
@@ -21,6 +21,8 @@
           <a href="#magazines" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">பூவிதழ் (Magazine)</a>
           <a href="#sponsors" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">Sponsors</a>
           <a href="#contact" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">Contact</a>
+          <a href="/register" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">Register</a>
+          <a href="/admin" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">Admin</a>
         </div>
       </div>
       
@@ -44,6 +46,8 @@
         <a href="#magazines" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">பூவிதழ் (Magazine)</a>
         <a href="#sponsors" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">Sponsors</a>
         <a href="#contact" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">Contact</a>
+        <a href="/register" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">Register</a>
+        <a href="/admin" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">Admin</a>
       </div>
     </div>
   </nav>

--- a/project/src/pages/admin.astro
+++ b/project/src/pages/admin.astro
@@ -1,0 +1,78 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Admin">
+  <section id="login-section" class="py-20 bg-gray-50">
+    <div class="max-w-md mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-6">Admin Login</h1>
+      <form id="admin-form" class="space-y-4">
+        <div>
+          <label for="admin-user" class="block text-sm font-medium text-gray-700">Username</label>
+          <input id="admin-user" type="text" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500" />
+        </div>
+        <div>
+          <label for="admin-pass" class="block text-sm font-medium text-gray-700">Password</label>
+          <input id="admin-pass" type="password" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500" />
+        </div>
+        <button type="submit" class="w-full bg-pink-600 hover:bg-pink-700 text-white px-6 py-3 rounded-lg font-semibold transition-colors">Login</button>
+      </form>
+    </div>
+  </section>
+
+  <section id="registrations-section" class="py-20 bg-white hidden">
+    <div class="max-w-xl mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-6">Registrations</h1>
+      <ul id="registrations" class="space-y-2"></ul>
+    </div>
+  </section>
+</Layout>
+
+<script>
+const tokenKey = 'adminToken';
+
+document.getElementById('admin-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('admin-user').value;
+  const password = document.getElementById('admin-pass').value;
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    localStorage.setItem(tokenKey, data.token);
+    loadRegistrations();
+  } else {
+    alert('Invalid credentials');
+  }
+});
+
+async function loadRegistrations() {
+  const token = localStorage.getItem(tokenKey);
+  if (!token) return;
+
+  const res = await fetch('/api/registrations', { headers: { 'Authorization': `Bearer ${token}` } });
+  if (res.ok) {
+    const xmlText = await res.text();
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xmlText, 'application/xml');
+    const list = document.getElementById('registrations');
+    list.innerHTML = '';
+    xmlDoc.querySelectorAll('registration').forEach((r) => {
+      const name = r.querySelector('name')?.textContent || '';
+      const email = r.querySelector('email')?.textContent || '';
+      const li = document.createElement('li');
+      li.textContent = `${name} - ${email}`;
+      list.appendChild(li);
+    });
+    document.getElementById('login-section').classList.add('hidden');
+    document.getElementById('registrations-section').classList.remove('hidden');
+  } else {
+    alert('Unauthorized');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadRegistrations);
+</script>

--- a/project/src/pages/api/login.ts
+++ b/project/src/pages/api/login.ts
@@ -1,0 +1,18 @@
+import crypto from 'crypto';
+
+export const prerender = false;
+
+const USER = 'admin';
+const PASS_HASH = crypto.createHash('sha256').update('admin').digest('hex');
+export const TOKEN = crypto.createHash('sha256').update('admin-session').digest('hex');
+
+export async function POST({ request }: { request: Request }) {
+  const { username, password } = await request.json();
+  const hash = crypto.createHash('sha256').update(password).digest('hex');
+  if (username === USER && hash === PASS_HASH) {
+    return new Response(JSON.stringify({ token: TOKEN }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+}

--- a/project/src/pages/api/register.ts
+++ b/project/src/pages/api/register.ts
@@ -1,0 +1,39 @@
+import fs from 'fs/promises';
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export const prerender = false;
+
+const fileUrl = new URL('../../../../data/registrations.xml', import.meta.url);
+
+async function ensureFile() {
+  try {
+    await fs.access(fileUrl);
+  } catch {
+    await fs.mkdir(new URL('../..', fileUrl), { recursive: true });
+    await fs.writeFile(fileUrl, '<registrations></registrations>');
+  }
+}
+
+export async function POST({ request }: { request: Request }) {
+  const { name, email } = await request.json();
+  if (!name || !email) {
+    return new Response('Invalid', { status: 400 });
+  }
+
+  await ensureFile();
+  let xml = await fs.readFile(fileUrl, 'utf-8');
+  const entry = `  <registration>\n    <name>${escapeXml(String(name))}</name>\n    <email>${escapeXml(String(email))}</email>\n  </registration>\n`;
+  xml = xml.replace('</registrations>', `${entry}</registrations>`);
+  await fs.writeFile(fileUrl, xml);
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/project/src/pages/api/registrations.ts
+++ b/project/src/pages/api/registrations.ts
@@ -1,0 +1,19 @@
+import fs from 'fs/promises';
+import { TOKEN } from './login';
+
+export const prerender = false;
+
+const fileUrl = new URL('../../../../data/registrations.xml', import.meta.url);
+
+export async function GET({ request }: { request: Request }) {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${TOKEN}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  try {
+    const xml = await fs.readFile(fileUrl, 'utf-8');
+    return new Response(xml, { headers: { 'Content-Type': 'application/xml' } });
+  } catch {
+    return new Response('<registrations></registrations>', { headers: { 'Content-Type': 'application/xml' } });
+  }
+}

--- a/project/src/pages/register.astro
+++ b/project/src/pages/register.astro
@@ -1,0 +1,42 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Register">
+  <section class="py-20 bg-gray-50">
+    <div class="max-w-md mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-6">Event Registration</h1>
+      <form id="register-form" class="space-y-4">
+        <div>
+          <label for="reg-name" class="block text-sm font-medium text-gray-700">Name *</label>
+          <input id="reg-name" type="text" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500" />
+        </div>
+        <div>
+          <label for="reg-email" class="block text-sm font-medium text-gray-700">Email *</label>
+          <input id="reg-email" type="email" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500" />
+        </div>
+        <button type="submit" class="w-full bg-pink-600 hover:bg-pink-700 text-white px-6 py-3 rounded-lg font-semibold transition-colors">Register</button>
+        <p id="register-message" class="text-green-600 hidden">Thank you for registering!</p>
+      </form>
+    </div>
+  </section>
+</Layout>
+
+<script>
+document.getElementById('register-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const name = document.getElementById('reg-name').value;
+  const email = document.getElementById('reg-email').value;
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email })
+  });
+  if (res.ok) {
+    document.getElementById('register-message').classList.remove('hidden');
+    e.target.reset();
+  } else {
+    alert('Registration failed');
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- add nav links for registration and admin
- create `register` and `admin` pages
- implement API endpoints for registration and admin login
- store registration data in XML file

## Testing
- `npm install`
- `npm run build` *(fails: NoAdapterInstalled)*

------
https://chatgpt.com/codex/tasks/task_e_686183198a4883279fd06bdf39d9189c