### PR TITLE
Add simple registration and admin pages

### DIFF
--- a/project/astro.config.mjs
+++ b/project/astro.config.mjs
@@ -1,8 +1,11 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
+import node from '@astrojs/node';
 
 // https://astro.build/config
 export default defineConfig({
+  output: 'server',
+  adapter: node({ mode: 'standalone' }),
   integrations: [tailwind()]
 });

--- a/project/data/registrations.xml
+++ b/project/data/registrations.xml
@@ -1,0 +1,1 @@
+<registrations></registrations>

--- a/project/package-lock.json
+++ b/project/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@penngal/website",
       "version": "1.0.0",
       "dependencies": {
+        "@astrojs/node": "^9.2.2",
         "@astrojs/tailwind": "^5.1.2",
         "astro": "^5.2.5",
         "tailwindcss": "^3.4.0"
@@ -64,6 +65,20 @@
         "unist-util-visit": "^5.0.0",
         "unist-util-visit-parents": "^6.0.1",
         "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/node": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/node/-/node-9.2.2.tgz",
+      "integrity": "sha512-PtLPuuojmcl9O3CEvXqL/D+wB4x5DlbrGOvP0MeTAh/VfKFprYAzgw1+45xsnTO+QvPWb26l1cT+ZQvvohmvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.6.1",
+        "send": "^1.2.0",
+        "server-destroy": "^1.0.1"
+      },
+      "peerDependencies": {
+        "astro": "^5.3.0"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -2323,6 +2338,15 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2421,6 +2445,12 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.177",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.177.tgz",
@@ -2432,6 +2462,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2500,6 +2539,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -2519,6 +2564,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/eventemitter3": {
@@ -2665,6 +2719,15 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -2978,6 +3041,31 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
@@ -2987,6 +3075,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -4073,6 +4167,27 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4253,6 +4368,18 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
@@ -4639,6 +4766,15 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5009,6 +5145,40 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
@@ -5143,6 +5313,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-width": {
@@ -5385,6 +5564,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {

--- a/project/package.json
+++ b/project/package.json
@@ -7,11 +7,13 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "start": "node ./dist/server/entry.mjs"
   },
   "dependencies": {
-    "astro": "^5.2.5",
+    "@astrojs/node": "^9.2.2",
     "@astrojs/tailwind": "^5.1.2",
+    "astro": "^5.2.5",
     "tailwindcss": "^3.4.0"
   }
 }

--- a/project/src/components/Header.astro
+++ b/project/src/components/Header.astro
@@ -21,6 +21,8 @@
           <a href="#magazines" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">பூவிதழ் (Magazine)</a>
           <a href="#sponsors" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">Sponsors</a>
           <a href="#contact" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">Contact</a>
+          <a href="/register" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">Register</a>
+          <a href="/admin" class="text-gray-700 hover:text-pink-600 px-3 py-2 text-sm font-medium transition-colors">Admin</a>
         </div>
       </div>
       
@@ -44,6 +46,8 @@
         <a href="#magazines" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">பூவிதழ் (Magazine)</a>
         <a href="#sponsors" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">Sponsors</a>
         <a href="#contact" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">Contact</a>
+        <a href="/register" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">Register</a>
+        <a href="/admin" class="text-gray-700 hover:text-pink-600 block px-3 py-2 text-base font-medium">Admin</a>
       </div>
     </div>
   </nav>

--- a/project/src/pages/admin.astro
+++ b/project/src/pages/admin.astro
@@ -1,0 +1,78 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Admin">
+  <section id="login-section" class="py-20 bg-gray-50">
+    <div class="max-w-md mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-6">Admin Login</h1>
+      <form id="admin-form" class="space-y-4">
+        <div>
+          <label for="admin-user" class="block text-sm font-medium text-gray-700">Username</label>
+          <input id="admin-user" type="text" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500" />
+        </div>
+        <div>
+          <label for="admin-pass" class="block text-sm font-medium text-gray-700">Password</label>
+          <input id="admin-pass" type="password" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500" />
+        </div>
+        <button type="submit" class="w-full bg-pink-600 hover:bg-pink-700 text-white px-6 py-3 rounded-lg font-semibold transition-colors">Login</button>
+      </form>
+    </div>
+  </section>
+
+  <section id="registrations-section" class="py-20 bg-white hidden">
+    <div class="max-w-xl mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-6">Registrations</h1>
+      <ul id="registrations" class="space-y-2"></ul>
+    </div>
+  </section>
+</Layout>
+
+<script>
+const tokenKey = 'adminToken';
+
+document.getElementById('admin-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('admin-user').value;
+  const password = document.getElementById('admin-pass').value;
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    localStorage.setItem(tokenKey, data.token);
+    loadRegistrations();
+  } else {
+    alert('Invalid credentials');
+  }
+});
+
+async function loadRegistrations() {
+  const token = localStorage.getItem(tokenKey);
+  if (!token) return;
+
+  const res = await fetch('/api/registrations', { headers: { 'Authorization': `Bearer ${token}` } });
+  if (res.ok) {
+    const xmlText = await res.text();
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xmlText, 'application/xml');
+    const list = document.getElementById('registrations');
+    list.innerHTML = '';
+    xmlDoc.querySelectorAll('registration').forEach((r) => {
+      const name = r.querySelector('name')?.textContent || '';
+      const email = r.querySelector('email')?.textContent || '';
+      const li = document.createElement('li');
+      li.textContent = `${name} - ${email}`;
+      list.appendChild(li);
+    });
+    document.getElementById('login-section').classList.add('hidden');
+    document.getElementById('registrations-section').classList.remove('hidden');
+  } else {
+    alert('Unauthorized');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadRegistrations);
+</script>

--- a/project/src/pages/api/login.ts
+++ b/project/src/pages/api/login.ts
@@ -1,0 +1,18 @@
+import crypto from 'crypto';
+
+export const prerender = false;
+
+const USER = 'admin';
+const PASS_HASH = crypto.createHash('sha256').update('admin').digest('hex');
+export const TOKEN = crypto.createHash('sha256').update('admin-session').digest('hex');
+
+export async function POST({ request }: { request: Request }) {
+  const { username, password } = await request.json();
+  const hash = crypto.createHash('sha256').update(password).digest('hex');
+  if (username === USER && hash === PASS_HASH) {
+    return new Response(JSON.stringify({ token: TOKEN }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+}

--- a/project/src/pages/api/register.ts
+++ b/project/src/pages/api/register.ts
@@ -1,0 +1,39 @@
+import fs from 'fs/promises';
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export const prerender = false;
+
+const fileUrl = new URL('../../../../data/registrations.xml', import.meta.url);
+
+async function ensureFile() {
+  try {
+    await fs.access(fileUrl);
+  } catch {
+    await fs.mkdir(new URL('../..', fileUrl), { recursive: true });
+    await fs.writeFile(fileUrl, '<registrations></registrations>');
+  }
+}
+
+export async function POST({ request }: { request: Request }) {
+  const { name, email } = await request.json();
+  if (!name || !email) {
+    return new Response('Invalid', { status: 400 });
+  }
+
+  await ensureFile();
+  let xml = await fs.readFile(fileUrl, 'utf-8');
+  const entry = `  <registration>\n    <name>${escapeXml(String(name))}</name>\n    <email>${escapeXml(String(email))}</email>\n  </registration>\n`;
+  xml = xml.replace('</registrations>', `${entry}</registrations>`);
+  await fs.writeFile(fileUrl, xml);
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/project/src/pages/api/registrations.ts
+++ b/project/src/pages/api/registrations.ts
@@ -1,0 +1,19 @@
+import fs from 'fs/promises';
+import { TOKEN } from './login';
+
+export const prerender = false;
+
+const fileUrl = new URL('../../../../data/registrations.xml', import.meta.url);
+
+export async function GET({ request }: { request: Request }) {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${TOKEN}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  try {
+    const xml = await fs.readFile(fileUrl, 'utf-8');
+    return new Response(xml, { headers: { 'Content-Type': 'application/xml' } });
+  } catch {
+    return new Response('<registrations></registrations>', { headers: { 'Content-Type': 'application/xml' } });
+  }
+}

--- a/project/src/pages/register.astro
+++ b/project/src/pages/register.astro
@@ -1,0 +1,42 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Register">
+  <section class="py-20 bg-gray-50">
+    <div class="max-w-md mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-6">Event Registration</h1>
+      <form id="register-form" class="space-y-4">
+        <div>
+          <label for="reg-name" class="block text-sm font-medium text-gray-700">Name *</label>
+          <input id="reg-name" type="text" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500" />
+        </div>
+        <div>
+          <label for="reg-email" class="block text-sm font-medium text-gray-700">Email *</label>
+          <input id="reg-email" type="email" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500" />
+        </div>
+        <button type="submit" class="w-full bg-pink-600 hover:bg-pink-700 text-white px-6 py-3 rounded-lg font-semibold transition-colors">Register</button>
+        <p id="register-message" class="text-green-600 hidden">Thank you for registering!</p>
+      </form>
+    </div>
+  </section>
+</Layout>
+
+<script>
+document.getElementById('register-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const name = document.getElementById('reg-name').value;
+  const email = document.getElementById('reg-email').value;
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email })
+  });
+  if (res.ok) {
+    document.getElementById('register-message').classList.remove('hidden');
+    e.target.reset();
+  } else {
+    alert('Registration failed');
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- add nav links for registration and admin
- create `register` and `admin` pages
- implement API endpoints for registration and admin login
- store registration data in XML file
- add Node adapter so build succeeds

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686183198a4883279fd06bdf39d9189c